### PR TITLE
Brachinous defeat

### DIFF
--- a/Prefabs/Enemies/Brachinous.tscn
+++ b/Prefabs/Enemies/Brachinous.tscn
@@ -1,8 +1,12 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://Scripts/EnemyAI/Enemy_3.gd" type="Script" id=1]
 
 [sub_resource type="CapsuleShape2D" id=1]
+
+[sub_resource type="CapsuleShape2D" id=2]
+radius = 25.0
+height = 40.0
 
 [node name="Brachinous" type="Node2D"]
 script = ExtResource( 1 )
@@ -11,6 +15,7 @@ pursueSpeed = 500
 [node name="Base" type="Node2D" parent="."]
 
 [node name="Kinematic Body" type="KinematicBody2D" parent="Base" groups=[
+"Enemies",
 "Hazard",
 ]]
 rotation = 1.5708
@@ -31,6 +36,18 @@ polygon = PoolVector2Array( 0, 0, 150, -400, -150, -400 )
 
 [node name="Timer" type="Timer" parent="Base"]
 
+[node name="StunedTimer" type="Timer" parent="Base"]
+wait_time = 4.0
+
+[node name="CollisionArea" type="Area2D" parent="Base"]
+visible = false
+collision_layer = 0
+collision_mask = 16
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Base/CollisionArea"]
+rotation = 1.5708
+shape = SubResource( 2 )
+
 [node name="RayCastParent" type="Node2D" parent="."]
 
 [node name="RayCast2D" type="RayCast2D" parent="RayCastParent"]
@@ -41,3 +58,5 @@ collision_mask = 34
 [connection signal="body_entered" from="Base/Area2D" to="." method="_on_Area2D_body_entered"]
 [connection signal="body_exited" from="Base/Area2D" to="." method="_on_Area2D_body_exited"]
 [connection signal="timeout" from="Base/Timer" to="." method="_on_Timer_timeout"]
+[connection signal="timeout" from="Base/StunedTimer" to="." method="_on_StunedTimer_timeout"]
+[connection signal="body_entered" from="Base/CollisionArea" to="." method="_on_CollisionArea_body_entered"]

--- a/Prefabs/Enemies/Full Enemies/Vorticella_full.tscn
+++ b/Prefabs/Enemies/Full Enemies/Vorticella_full.tscn
@@ -14,6 +14,7 @@ script = ExtResource( 1 )
 rotation = -1.5708
 
 [node name="KinematicBody2D" type="KinematicBody2D" parent="Base" groups=[
+"Enemies",
 "Hazard",
 ]]
 rotation = 1.5708

--- a/Prefabs/Enemies/Stentour.tscn
+++ b/Prefabs/Enemies/Stentour.tscn
@@ -15,6 +15,7 @@ pullForce = 10
 [node name="Base" type="Node2D" parent="."]
 
 [node name="Kinematic Body" type="KinematicBody2D" parent="Base" groups=[
+"Enemies",
 "Hazard",
 ]]
 rotation = 1.5708

--- a/Prefabs/Enemies/Vorticella.tscn
+++ b/Prefabs/Enemies/Vorticella.tscn
@@ -11,6 +11,7 @@ script = ExtResource( 1 )
 rotation = -1.5708
 
 [node name="KinematicBody2D" type="KinematicBody2D" parent="Base" groups=[
+"Enemies",
 "Hazard",
 ]]
 rotation = 1.5708

--- a/Scnes Bloob/Test_enemies.tscn
+++ b/Scnes Bloob/Test_enemies.tscn
@@ -31,7 +31,7 @@ _data = {
 
 [sub_resource type="Curve2D" id=4]
 _data = {
-"points": PoolVector2Array( 0, 0, 0, 0, 1920, 3936, 0, 0, 0, 0, 2080, 4032, 0, 0, 0, 0, 2272, 4064, 0, 0, 0, 0, 2496, 4096, 0, 0, 0, 0, 2784, 3968, 0, 0, 0, 0, 2880, 4096, 0, 0, 0, 0, 2976, 4224, 0, 0, 0, 0, 3264, 4000, 0, 0, 0, 0, 3488, 4064, 0, 0, 0, 0, 2400, 3680 )
+"points": PoolVector2Array( 0, 0, 0, 0, 3274.22, 3685.31, 0, 0, 0, 0, 3267.49, 3893.86, 0, 0, 0, 0, 3270.85, 4056.99 )
 }
 
 [sub_resource type="Curve2D" id=5]
@@ -178,6 +178,14 @@ curve = SubResource( 3 )
 item_type = 0
 
 [node name="Path2D" parent="Hazard/Path Item2" index="0"]
+curve = SubResource( 4 )
+
+[node name="Path Item3" parent="Hazard" instance=ExtResource( 4 )]
+position = Vector2( -1969.33, -2073.98 )
+item_type = 0
+
+[node name="Path2D" parent="Hazard/Path Item3" index="0"]
+position = Vector2( 0, 2.99658 )
 curve = SubResource( 4 )
 
 [node name="WallsPolygon" type="Node2D" parent="."]
@@ -392,10 +400,10 @@ curve = SubResource( 15 )
 position = Vector2( 2001.13, 1616.66 )
 
 [node name="Navigation2D" parent="Enemies" instance=ExtResource( 5 )]
-position = Vector2( 945.194, 1802.17 )
+position = Vector2( 1401.11, 3478.88 )
 
 [node name="Navigation2D2" parent="Enemies" instance=ExtResource( 13 )]
-position = Vector2( 2766.3, 2000.04 )
+position = Vector2( 960.975, 1830.53 )
 
 [node name="boxes" type="Node2D" parent="."]
 
@@ -410,7 +418,7 @@ is_curved = true
 [node name="CollisionPolygon2D" parent="boxes/Caja2" index="0"]
 polygon = PoolVector2Array( 71.1108, -101.333, 96, -32, 96, 0, 96, 32, 64, 96, 0, 122.667, -67.5557, 106.667, -113.778, 56.8889, -87.1113, 40.8889, -81.7778, 24.8889, -72.8892, 1.77783, -87.1113, -26.6667, -113.778, -56.8889, -62.2222, -103.111, 0, -108.444 )
 
-[node name="Path2D" parent="boxes/Caja2" index="2"]
+[node name="Path2D" parent="boxes/Caja2" index="3"]
 curve = SubResource( 16 )
 
 [node name="Caja3" parent="boxes" instance=ExtResource( 7 )]
@@ -423,7 +431,7 @@ is_curved = true
 [node name="CollisionPolygon2D" parent="boxes/Caja3" index="0"]
 polygon = PoolVector2Array( 117, 3571, 208, 3567, 309, 3570, 303, 3825, 196, 3831, 105, 3818, 101, 3689 )
 
-[node name="Path2D" parent="boxes/Caja3" index="2"]
+[node name="Path2D" parent="boxes/Caja3" index="3"]
 curve = SubResource( 17 )
 
 [node name="Caja8" parent="boxes" instance=ExtResource( 7 )]
@@ -436,7 +444,7 @@ is_curved = true
 [node name="CollisionPolygon2D" parent="boxes/Caja8" index="0"]
 polygon = PoolVector2Array( 99, 3590, 208, 3567, 307, 3591, 300, 3812, 196, 3828, 92, 3808 )
 
-[node name="Path2D" parent="boxes/Caja8" index="2"]
+[node name="Path2D" parent="boxes/Caja8" index="3"]
 curve = SubResource( 17 )
 
 [node name="Caja4" parent="boxes" instance=ExtResource( 7 )]
@@ -459,7 +467,7 @@ is_curved = true
 [node name="CollisionPolygon2D" parent="boxes/Caja5" index="0"]
 polygon = PoolVector2Array( -174, 3212, -139, 3258, -163, 3314, -235, 3309, -245, 3267, -232, 3226, -206, 3210 )
 
-[node name="Path2D" parent="boxes/Caja5" index="2"]
+[node name="Path2D" parent="boxes/Caja5" index="3"]
 curve = SubResource( 18 )
 
 [node name="Caja6" parent="boxes" instance=ExtResource( 7 )]
@@ -472,7 +480,7 @@ is_curved = true
 [node name="CollisionPolygon2D" parent="boxes/Caja6" index="0"]
 polygon = PoolVector2Array( -174, 3212, -159, 3257, -163, 3314, -235, 3309, -232, 3226, -206, 3210 )
 
-[node name="Path2D" parent="boxes/Caja6" index="2"]
+[node name="Path2D" parent="boxes/Caja6" index="3"]
 curve = SubResource( 19 )
 
 [node name="Caja7" parent="boxes" instance=ExtResource( 7 )]
@@ -485,7 +493,7 @@ is_curved = true
 [node name="CollisionPolygon2D" parent="boxes/Caja7" index="0"]
 polygon = PoolVector2Array( -157, 3193, -131, 3256, -161, 3310, -254, 3300, -248, 3217, -203, 3197 )
 
-[node name="Path2D" parent="boxes/Caja7" index="2"]
+[node name="Path2D" parent="boxes/Caja7" index="3"]
 curve = SubResource( 20 )
 
 [node name="Caja puzzle" parent="boxes" instance=ExtResource( 7 )]
@@ -497,7 +505,7 @@ is_curved = true
 [node name="CollisionPolygon2D" parent="boxes/Caja puzzle" index="0"]
 polygon = PoolVector2Array( 2752, 2752, 2752, 2784, 2708, 2802, 2620, 2815, 2599, 2790, 2633, 2745, 2688, 2720 )
 
-[node name="Path2D" parent="boxes/Caja puzzle" index="2"]
+[node name="Path2D" parent="boxes/Caja puzzle" index="3"]
 curve = SubResource( 21 )
 
 [node name="Caja puzzle2" parent="boxes" instance=ExtResource( 7 )]
@@ -509,7 +517,7 @@ is_curved = true
 [node name="CollisionPolygon2D" parent="boxes/Caja puzzle2" index="0"]
 polygon = PoolVector2Array( 2635, 2952, 2703, 2952, 2705, 2924, 2672, 2916, 2636, 2923 )
 
-[node name="Path2D" parent="boxes/Caja puzzle2" index="2"]
+[node name="Path2D" parent="boxes/Caja puzzle2" index="3"]
 curve = SubResource( 22 )
 
 [node name="Caja puzzle3" parent="boxes" instance=ExtResource( 7 )]
@@ -522,7 +530,7 @@ is_curved = true
 [node name="CollisionPolygon2D" parent="boxes/Caja puzzle3" index="0"]
 polygon = PoolVector2Array( 2170, 2392, 2219, 2371, 2232, 2400, 2213, 2434, 2172, 2443 )
 
-[node name="Path2D" parent="boxes/Caja puzzle3" index="2"]
+[node name="Path2D" parent="boxes/Caja puzzle3" index="3"]
 curve = SubResource( 23 )
 
 [node name="Caja puzzle4" parent="boxes" instance=ExtResource( 7 )]
@@ -534,7 +542,7 @@ is_curved = true
 [node name="CollisionPolygon2D" parent="boxes/Caja puzzle4" index="0"]
 polygon = PoolVector2Array( 2799, 2388, 2781, 2436, 2703, 2469, 2601, 2481, 2572, 2469, 2571, 2429, 2590, 2385, 2646, 2363, 2773, 2376 )
 
-[node name="Path2D" parent="boxes/Caja puzzle4" index="2"]
+[node name="Path2D" parent="boxes/Caja puzzle4" index="3"]
 curve = SubResource( 24 )
 
 [node name="Caja puzzle5" parent="boxes" instance=ExtResource( 7 )]
@@ -546,7 +554,7 @@ is_curved = true
 [node name="CollisionPolygon2D" parent="boxes/Caja puzzle5" index="0"]
 polygon = PoolVector2Array( 3174, 2378, 3183, 2298, 3219, 2299, 3229, 2382 )
 
-[node name="Path2D" parent="boxes/Caja puzzle5" index="2"]
+[node name="Path2D" parent="boxes/Caja puzzle5" index="3"]
 curve = SubResource( 25 )
 
 [node name="Gates" type="Node2D" parent="."]
@@ -558,6 +566,8 @@ curve = SubResource( 25 )
 [editable path="Hazard/Path Item"]
 
 [editable path="Hazard/Path Item2"]
+
+[editable path="Hazard/Path Item3"]
 
 [editable path="WallsPolygon/Wall_poly"]
 


### PR DESCRIPTION
The brachinous enemy can now interact with hazards to get stunned. The time it is stunned is infinite but can be temporal just removing a comment inside it's collision detection script.
Enemies are now inside 2 groups: Hazards and Enemies. This was done so the Collision event can distinguish enemies and hazards. While the enemy is stunned, it cannot harm the player. This last bit hasn't been applied to the 2 previous enemies but it can be implemented just adding and removing them from the "Hazard" group.